### PR TITLE
Restore Pygame config in index.html for diagnostic test

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
     <script defer src="https://pyscript.net/latest/pyscript.js"></script>
-    <!-- <py-config>
+    <py-config>
         packages = ["pygame"]
-    </py-config> -->
+    </py-config>
 </head>
 <body>
     <h1>Earth Invaders</h1>


### PR DESCRIPTION
This commit uncomments the <py-config> section in index.html to re-enable the loading of the Pygame package by PyScript.

The main game.py script remains commented out. A simple inline diagnostic print is still active. This is to test if PyScript can successfully load Pygame and still execute a basic script, or if package loading itself is a point of failure.