### PR TITLE
Add py-terminal to index.html for enhanced diagnostics

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,12 @@
 </head>
 <body>
     <h1>Earth Invaders</h1>
+    <py-terminal auto-generate="true"></py-terminal>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
 
     <py-script src="game.py"></py-script>
-    <py-script>
+    <!-- <py-script>
         print("DIAGNOSTIC_PRINT: Inline PyScript after game.py executed.")
-    </py-script>
+    </py-script> -->
 </body>
 </html>


### PR DESCRIPTION
This commit adds a <py-terminal auto-generate="true"></py-terminal> element to index.html. This is intended to provide a visible area on the web page where PyScript might output messages, including print() statements from Python code, which could help diagnose why game.py's diagnostic prints are not appearing in your browser's developer console.

The previous small inline diagnostic script has been commented out to focus on the output from game.py via the py-terminal.